### PR TITLE
Fix a few simple typos

### DIFF
--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -422,7 +422,7 @@
 JSON-LD keywords to express the global identifier and object type:</figcaption>
 <pre class="example highlight json">
 {
-  "@id": "http://example.org/foo",f
+  "@id": "http://example.org/foo",
   "@type": "http://example.org/types/Note",
   "language": "en",
   "displayName": "This is a note",
@@ -711,7 +711,7 @@ function _fixdefaultlanguage(lang, obj) {
       "rel": "preview",
       "mediaType": "image/jpeg",
       "height": 200,
-      "widht": 200
+      "width": 200
     }
   ]
 }</pre></figure>
@@ -1325,7 +1325,7 @@ function _fixdefaultlanguage(lang, obj) {
         </tr>
         <tr>
           <td>Contact: </td>
-          <td>James M Snell &lt;<a href="mailto:jasnell@gmail.com">jasnell@gmail.com</a></td>
+          <td>James M Snell &lt;<a href="mailto:jasnell@gmail.com">jasnell@gmail.com</a>&gt;</td>
         </tr>
         </table>
 


### PR DESCRIPTION
- trailing "f" in a json example
- "widht" => "width"
- Add &gt; after James Snell's email address
