### PR TITLE
Clarify in core that Links can have 'id'

### DIFF
--- a/core/index.html
+++ b/core/index.html
@@ -734,6 +734,7 @@ as2-date-time    = full-date "T" as2-full-time
         property. In addition, all <code>Link</code> instances share the
         following common set of optional properties as normatively defined by
         the <a href="../activitystreams-vocabulary/">Activity Vocabulary</a>:
+          <code><a href="../activitystreams-vocabulary/#dfn-id">id</a></code> |
           <code><a href="../activitystreams-vocabulary/#dfn-name">name</a></code> |
           <code><a href="../activitystreams-vocabulary/#dfn-hreflang">hreflang</a></code> |
           <code><a href="../activitystreams-vocabulary/#dfn-mediatype">mediaType</a></code> |


### PR DESCRIPTION
Vocabulary does describe id property as "Provides the globally unique identifier for an Object or Link."

But it's ambiguous reading core whether that's ok, since it's omitted from this section.

This pull resolves https://github.com/w3c/activitystreams/issues/288