### PR TITLE
Add datetime and boolean to range of "closed" property

### DIFF
--- a/vocabulary/index.html
+++ b/vocabulary/index.html
@@ -3991,7 +3991,10 @@
         </tr>
         <tr>
           <td>Range:</td>
-          <td><code><a>Object</a></code> | <code><a>Link</a></code></td>
+          <td>
+            <code><a>Object</a></code> | <code><a>Link</a></code> |
+            <code>xsd:dateTime</code> | <code>xsd:boolean</code>
+          </td>
         </tr>
       </tbody>
 


### PR DESCRIPTION
Should be editorial since it doesn't break implementations, but permits the range to match examples (which use a date).  I'd also be okay with datetime only.