### PR TITLE
Fix typo in deleted range

### DIFF
--- a/vocabulary/index.html
+++ b/vocabulary/index.html
@@ -5764,7 +5764,7 @@
       </tr>
       <tr>
         <td>Range:</td>
-        <td><code><a>Object</a></code></td>
+        <td><code>xsd:dateTime</code></td>
       </tr>
       <tr>
         <td>Functional:</td>


### PR DESCRIPTION
From description, clearly meant to be a dateTime.

This shoud be just an editorial change; it's clear from the description that a timestamp is meant, and the current range is just a typo.