### PR TITLE
Add attachments, tags, author to as1-context

### DIFF
--- a/core/activitystreams1-context.jsonld
+++ b/core/activitystreams1-context.jsonld
@@ -5,7 +5,10 @@
        "id": "@id",
        "objectType": "@type",
        "verb": "@type",
-       "displayName": "as:name"
+       "displayName": "as:name",
+       "attachments": "as:attachment",
+       "tags": "as:tag",
+       "author": "as:attributedTo"
     }
   ]
 }


### PR DESCRIPTION
As these terms were removed from the as2 context recently
https://github.com/w3c/activitystreams/commit/65ea6c58ad543d73c98ab78d1e096e1338f7a7b4

Related to #375 