### PR TITLE
distbin.com paging & startIndex in impl report template

### DIFF
--- a/implementation-reports/distbin.com
+++ b/implementation-reports/distbin.com
@@ -58,13 +58,13 @@ Implemented? : n
 
 ### Link
 
-Implemented? : n
+Implemented? : y
 
 * height: n
 * hreflang: n
-* mediaType: n
-* name: n
-* rel: n
+* mediaType: y
+* name: y
+* rel: y
 * width: n
 
 ### Actor

--- a/implementation-reports/distbin.com
+++ b/implementation-reports/distbin.com
@@ -92,7 +92,7 @@ Implemented? : y (/public and /:activity/replies are represented as Collections 
 
 * items: y
 * totalItems: y
-* first: n
+* first: y
 * last: n
 * current: y
 
@@ -104,13 +104,15 @@ Implemented? : n
 
 Implemented? : n
 
-* partOf: n
-* next: n
+* partOf: y
+* next: y
 * prev: n
 
 ### OrderedCollectionPage
 
-Implemented? : n
+Implemented? : y
+
+* startIndex: y
 
 ## Extended classes
 

--- a/implementation-reports/template.md
+++ b/implementation-reports/template.md
@@ -117,6 +117,8 @@ Implemented? : %"y", "n"% (%comments%)
 
 Implemented? : %"y", "n"% (%comments%)
 
+* startIndex: %"y", "n"% (%comments%)
+
 ## Extended classes
 
 ### Accept


### PR DESCRIPTION
Distbin's public collection supports paging including limiting the items per page via max-member-count querystring parameter or [Prefer header argument defined in LDP Paging](https://www.w3.org/2012/ldp/hg/ldp-paging.html#ldpp-hints).

e.g. to page through by 2: http://distbin.com/public?max-member-count=2

Pro tip: You can use the collection renderer to render on distbin.com to render (and page through) other CollectionPages by using the `?page=url` querystring parameter.

e.g. http://distbin.com/public?page=https://rawgit.com/gobengo/171d9774382c31850ecf03a8a5611fac/raw/bc35d935705ee1a4199eaa2db1679192e44ccb1c/page1.json