### PR TITLE
Update distbin.com impl report to use .attachment and .mediaType

### DIFF
--- a/implementation-reports/distbin.com
+++ b/implementation-reports/distbin.com
@@ -26,7 +26,7 @@ distbin.com is not very strict about documents it allows end-users to publish, a
 
 Implemented? : n
 
-* attachment: n
+* attachment: y
 * attributedTo: n
 * audience: n
 * bcc: y (notifies LDN inbox of any bcc'd URL)
@@ -42,7 +42,7 @@ Implemented? : n
 * image: n
 * inReplyTo: y (notifies LDN inbox of inReplyTo URL, renders threaded replies in HTML representation)
 * location: n
-* mediaType: n
+* mediaType: y
 * name: y (rendered as header in HTML representation)
 * nameMap: n
 * preview: n


### PR DESCRIPTION
On distbin.com you can now specify a URL to attach to your post. If that resource prefers to respond as Content-Type: image/something, it will be rendered on the activity's HTML page.

http://distbin.com/activities/bdc12eca-07d7-44de-ac01-e060a4a887a6