### PR TITLE
distbin.com implements .location, Place

### DIFF
--- a/implementation-reports/distbin.com
+++ b/implementation-reports/distbin.com
@@ -27,7 +27,7 @@ distbin.com is not very strict about documents it allows end-users to publish, a
 Implemented? : n
 
 * attachment: y
-* attributedTo: n
+* attributedTo: y
 * audience: n
 * bcc: y (notifies LDN inbox of any bcc'd URL)
 * bto: y (notifies LDN inbox of any bto'd URL)

--- a/implementation-reports/distbin.com
+++ b/implementation-reports/distbin.com
@@ -286,7 +286,7 @@ Implemented? : n
 
 Implemented? : y
 
-* accuracy: n
+* accuracy: y
 * altitude: y
 * latitude: y
 * longitude: y

--- a/implementation-reports/distbin.com
+++ b/implementation-reports/distbin.com
@@ -41,7 +41,7 @@ Implemented? : n
 * icon: n
 * image: n
 * inReplyTo: y (notifies LDN inbox of inReplyTo URL, renders threaded replies in HTML representation)
-* location: n
+* location: y (User can provide geolocation when posting. Renders map in HTML)
 * mediaType: y
 * name: y (rendered as header in HTML representation)
 * nameMap: n
@@ -284,14 +284,14 @@ Implemented? : n
 
 ### Place
 
-Implemented? : n
+Implemented? : y
 
 * accuracy: n
-* altitude: n
-* latitude: n
-* longitude: n
-* radius: n
-* units: n
+* altitude: y
+* latitude: y
+* longitude: y
+* radius: y
+* units: y
 
 ### Profile
 


### PR DESCRIPTION
When creating an activity, you can use the [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation) to specify your coordinates and/or you can just type a .location.name.

If a .location is provided, a globe appears when the activity is rendered. You can click on the globe to see a map of the .location.

Example: https://distbin.com/activities/d74ec7aa-f98a-44d6-81df-a6b598086cf8
