### PR TITLE
Add type property to only two examples that dont have it

### DIFF
--- a/vocabulary/index.html
+++ b/vocabulary/index.html
@@ -2905,6 +2905,7 @@
 <div id="exid-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Object",
   "name": "Foo",
   "id": "http://example.org/foo"
 }</pre>
@@ -4241,6 +4242,7 @@
     "name": "Trailer",
     "duration": "PT1M",
     "url": {
+      "type": "Link",
       "href": "http://example.org/trailer.mkv",
       "mediaType": "video/mkv"
     }


### PR DESCRIPTION
I've been doing some scraping of this spec, and then subsequent JSON-LD validation. In doing so, my program caught that two examples don't specify the `type` property and thus have no `@type`.

This adds them.