### PR TITLE
URI of type and id properties are actually URIs

### DIFF
--- a/vocabulary/index.html
+++ b/vocabulary/index.html
@@ -2900,7 +2900,7 @@
         <tr>
           <td rowspan="5"><dfn>id</dfn></td>
           <td style="width: 10%">URI:</td>
-          <td><code>@id</code></td>
+          <td><code>https://www.w3.org/ns/activitystreams#id</code></td>
           <td rowspan="5">
 <div id="exid-jsonld" style="display: block;">
 <pre class="example highlight json">{
@@ -2936,7 +2936,7 @@
         <tr>
           <td rowspan="4"><dfn>type</dfn></td>
           <td style="width: 10%">URI:</td>
-          <td><code>@type</code></td>
+          <td><code>https://www.w3.org/ns/activitystreams#type</code></td>
           <td rowspan="4">
 <div id="extype-jsonld" style="display: block;">
 <pre class="example highlight json">{


### PR DESCRIPTION

Each property in the activitystreams-vocabulary document has a 'URI:' described. For most properties, the value of this table cell is what I'd expect, e.g. the URI of 'name' is `https://www.w3.org/ns/activitystreams#name`. Said another way, the URI of the property is what you'd get by expanding the term 'as:name' given the activitystreams2 JSON-LD context.

However, the 'URI' for 'id' is said to be '@id', and the 'URI' for 'type' is said to be '@type'.

Notably, '@id' and '@type' are not [RFC 3986](https://tools.ietf.org/html/rfc3986) URIs.

I am aware that simply JSON-LD expanding 'id' and 'type' against the AS2 context will result in '@id' and '@type' respectively, but that's not the same as those '@'-values being the URIs of the properties.

