### PR TITLE
Issue 477

### DIFF
--- a/ns/activitystreams.jsonld
+++ b/ns/activitystreams.jsonld
@@ -4,6 +4,7 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "as": "https://www.w3.org/ns/activitystreams#",
     "ldp": "http://www.w3.org/ns/ldp#",
+    "sec": "https://w3id.org/security#",
     "id": "@id",
     "type": "@type",
     "Accept": "as:Accept",

--- a/ns/index.html
+++ b/ns/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html><html dir="ltr" typeof="bibo:Document " prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54# as: https://www.w3.org/ns/activitystreams#" lang="en"><head><meta charset="utf-8"><meta name="generator" content="ReSpec 20.7.1"><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"><meta property="dc:language" content="en" lang="">
     <title>ActivityStreams 2.0 Terms</title>
-    
-    
-    
+
+
+
   <style>/*****************************************************************
  * ReSpec 3 CSS
  * Robin Berjon - http://berjon.com/
@@ -152,7 +152,7 @@ aside.example div.example div.example-title {
 }
 </style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-FPWD"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
 
-    
+
 <style id="respec-mainstyle">/*****************************************************************
  * ReSpec 3 CSS
  * Robin Berjon - http://berjon.com/
@@ -389,39 +389,39 @@ details.respec-tests-details > li {
       <img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48">
   </a>
   <h1 id="title" class="title p-name">ActivityStreams 2.0 Terms</h1>
-  
+
   <h2 id="w3c-document-13-april-2018"><abbr title="World Wide Web Consortium">W3C</abbr> Document <time class="dt-published" datetime="2018-04-13">13 April 2018</time></h2>
   <dl>
-    
+
     <dt>Latest editor's draft:</dt><dd><a href="https://rhiaro.github.io/as-ns">https://rhiaro.github.io/as-ns</a></dd>
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
     <dt>Editor:</dt>
     <dd class="p-author h-card vcard"><a class="u-url url p-name fn" href="https://rhiaro.co.uk/">Amy Guy</a> (<a class="p-org org h-org h-card" href="https://w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a>)</dd>
-    
-    
+
+
     <dt>Source:</dt><dd>
       <a href="https://github.com/rhiaro/as-ns">Repository on Github.</a>
     </dd><dd>
       <a href="https://github.com/w3c/activitystreams/issues">Issues</a>
     </dd>
   </dl>
-  
-  
-  
+
+
+
   <p class="copyright">
         <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
         2018
-        
+
         <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
         <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
         <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
-        
+
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
         <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
         <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a>
@@ -450,6 +450,8 @@ details.respec-tests-details > li {
       <dd><code>http://www.w3.org/2001/XMLSchema#</code></dd>
       <dt><code>ldp</code>:</dt>
       <dd><code>http://www.w3.org/ns/ldp#</code></dd>
+      <dt><code>sec</code>:</dt>
+      <dd><code>https://w3id.org/security#</code></dd>
     </dl>
   </section>
 
@@ -485,7 +487,7 @@ details.respec-tests-details > li {
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-service" id="Service">Service</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-tombstone" id="Tombstone">Tombstone</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-video" id="Video">Video</a> </li>
-      
+
     </ul>
     <h2 id="activities">Activities</h2>
     <ul>
@@ -516,7 +518,7 @@ details.respec-tests-details > li {
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-undo" id="Undo">Undo</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-update" id="Update">Update</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-view" id="View">View</a> </li>
-      
+
     </ul>
     <h3 id="links-and-relationships">Links and Relationships</h3>
     <ul>
@@ -641,7 +643,7 @@ details.respec-tests-details > li {
 
   </section>
 
-  
+
 
 <style type="text/css">
     /* loading */


### PR DESCRIPTION
Close issue #477 by including sec: namespace, used for HTTP signatures.

(Note: I accidentally referenced #447; I'll fix that when merged.)