### PR TITLE
Extension: alsoKnownAs from DID Core

### DIFF
--- a/ns/activitystreams.jsonld
+++ b/ns/activitystreams.jsonld
@@ -370,6 +370,10 @@
     "shares": {
       "@id": "as:shares",
       "@type": "@id"
+    },
+    "alsoKnownAs": {
+      "@id": "as:alsoKnownAs",
+      "@type": "@id"
     }
   }
 }

--- a/ns/index.html
+++ b/ns/index.html
@@ -436,7 +436,7 @@ details.respec-tests-details > li {
         This document is merely a <abbr title="World Wide Web Consortium">W3C</abbr>-internal  document. It
         has no official standing of any kind and does not represent consensus of the <abbr title="World Wide Web Consortium">W3C</abbr>
         Membership.
-      </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a href="#h-introduction" class="tocxref"><span class="secno">1. </span><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></a></li><li class="tocline"><a href="#class-definitions" class="tocxref"><span class="secno">2. </span>Class definitions</a></li><li class="tocline"><a href="#property-definitions" class="tocxref"><span class="secno">3. </span>Property definitions</a></li><li class="tocline"><a href="#extensions" class="tocxref"><span class="secno">4. </span>Extensions</a><ol class="toc"><li class="tocline"><a href="#activitypub" class="tocxref"><span class="secno">4.1 </span>ActivityPub</a></li></ol></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ol class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ol></li></ol></nav>
+      </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a href="#h-introduction" class="tocxref"><span class="secno">1. </span><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></a></li><li class="tocline"><a href="#class-definitions" class="tocxref"><span class="secno">2. </span>Class definitions</a></li><li class="tocline"><a href="#property-definitions" class="tocxref"><span class="secno">3. </span>Property definitions</a></li><li class="tocline"><a href="#extensions" class="tocxref"><span class="secno">4. </span>Extensions</a><ol class="toc"><li class="tocline"><a href="#activitypub" class="tocxref"><span class="secno">4.1 </span>ActivityPub</a></li><li class="tocline"><a href="#additional-terms" class="tocxref"><span class="secno">4.2 </span>Additional terms</a></li></ol></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ol class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ol></li></ol></nav>
 
   <section property="bibo:hasPart" resource="#introduction" typeof="bibo:Chapter" id="introduction">
     <!--OddPage-->
@@ -644,6 +644,14 @@ details.respec-tests-details > li {
       </ul>
     </section>
 
+    <section id="additional-terms">
+      <h3 id="x4-2-additional-terms"><span class="secno">4.2 </span>Additional terms</h3>
+      <p>The terms in this section are linked to their normative definitions in external specifications.</p>
+      <ul>
+        <li><a href="https://www.w3.org/TR/did-core/#dfn-alsoknownas" id="alsoKnownAs">alsoKnownAs</a> [<cite><a class="bibref" href="#bib-did-core">DID-CORE</a></cite>]</li>
+      </ul>
+    </section>
+
   </section>
 
 
@@ -687,4 +695,4 @@ details.respec-tests-details > li {
   </style><section id="references" class="appendix"><!--OddPage--><h2 id="a-references"><span class="secno">A. </span>References</h2><section id="normative-references"><h3 id="a-1-normative-references"><span class="secno">A.1 </span>Normative references</h3><dl class="bibliography"><dt id="bib-ActivityPub">[ActivityPub]</dt><dd><a href="https://www.w3.org/TR/activitypub/"><cite>ActivityPub</cite></a>. Christopher Webber; Jessica Tallon. W3C. 23 January 2018. W3C Recommendation. URL: <a href="https://www.w3.org/TR/activitypub/">https://www.w3.org/TR/activitypub/</a>
 </dd><dt id="bib-ActivityStreams">[ActivityStreams]</dt><dd><a href="https://w3.org/TR/activitystreams-core"><cite>ActivityStreams 2.0</cite></a>. James Snell; Evan Prodromou. W3C. W3C Candidate Recommendation. URL: <a href="https://w3.org/TR/activitystreams-core">https://w3.org/TR/activitystreams-core</a>
 </dd><dt id="bib-ActivityStreamsVocab">[ActivityStreamsVocab]</dt><dd><a href="https://w3.org/TR/activitystreams-vocabulary"><cite>ActivityStreams 2.0 Vocabulary</cite></a>. James Snell; Evan Prodromou. W3C. W3C Candidate Recommendation. URL: <a href="https://w3.org/TR/activitystreams-vocabulary">https://w3.org/TR/activitystreams-vocabulary</a>
-</dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>
+</dd><dt id="bib-did-core">[DID-CORE]</dt><dd><a href="https://www.w3.org/TR/did-core/"><cite>Decentralized Identifiers (DIDs) v1.0</cite></a>. Drummond Reed; Manu Sporny; Markus Sabadello; Dave Longley; Christopher Allen.  W3C. 13 November 2019. W3C Working Draft. URL: <a href="https://www.w3.org/TR/did-core/">https://www.w3.org/TR/did-core/</a></dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>

--- a/ns/index.html
+++ b/ns/index.html
@@ -436,7 +436,7 @@ details.respec-tests-details > li {
         This document is merely a <abbr title="World Wide Web Consortium">W3C</abbr>-internal  document. It
         has no official standing of any kind and does not represent consensus of the <abbr title="World Wide Web Consortium">W3C</abbr>
         Membership.
-      </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a href="#h-introduction" class="tocxref"><span class="secno">1. </span><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></a></li><li class="tocline"><a href="#class-definitions" class="tocxref"><span class="secno">2. </span>Class definitions</a></li><li class="tocline"><a href="#property-definitions" class="tocxref"><span class="secno">3. </span>Property definitions</a></li><li class="tocline"><a href="#extensions" class="tocxref"><span class="secno">4. </span>Extensions</a><ol class="toc"><li class="tocline"><a href="#activitypub" class="tocxref"><span class="secno">4.1 </span>ActivityPub</a></li><li class="tocline"><a href="#additional-terms" class="tocxref"><span class="secno">4.2 </span>Additional terms</a></li></ol></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ol class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ol></li></ol></nav>
+      </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a href="#h-introduction" class="tocxref"><span class="secno">1. </span><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></a></li><li class="tocline"><a href="#class-definitions" class="tocxref"><span class="secno">2. </span>Class definitions</a></li><li class="tocline"><a href="#property-definitions" class="tocxref"><span class="secno">3. </span>Property definitions</a></li><li class="tocline"><a href="#extensions" class="tocxref"><span class="secno">4. </span>Extensions</a><ol class="toc"><li class="tocline"><a href="#activitypub" class="tocxref"><span class="secno">4.1 </span>ActivityPub</a></li><li class="tocline"><a href="#did-core" class="tocxref"><span class="secno">4.2 </span>DID Core</a></li></ol></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ol class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ol></li></ol></nav>
 
   <section property="bibo:hasPart" resource="#introduction" typeof="bibo:Chapter" id="introduction">
     <!--OddPage-->
@@ -617,7 +617,7 @@ details.respec-tests-details > li {
 
   <section id="extensions">
     <!--OddPage--><h2 id="x4-extensions"><span class="secno">4. </span>Extensions</h2>
-    <p>This namespaced may be used by extensions to AS2 which are considered stable. The extensions must document their terms in a spec-like way at a persistant URL. Approval of extensions will be by the Social Web WG until it closes, and after that by the followup Community Group. Process and criteria for extensions approval is being finalised and will be described or linked to here in due course.</p>
+    <p>This namespace may be used by extensions to AS2 which are considered stable. The extensions must document their terms in a spec-like way at a persistant URL. Approval of extensions will be by the Social Web WG until it closes, and after that by the followup Community Group. Process and criteria for extensions approval is being finalised and will be described or linked to here in due course.</p>
 
     <section id="activitypub">
       <h3 id="x4-1-activitypub"><span class="secno">4.1 </span>ActivityPub</h3>
@@ -644,11 +644,16 @@ details.respec-tests-details > li {
       </ul>
     </section>
 
-    <section id="additional-terms">
-      <h3 id="x4-2-additional-terms"><span class="secno">4.2 </span>Additional terms</h3>
-      <p>The terms in this section are linked to their normative definitions in external specifications.</p>
+    <section id="did-core">
+      <h3 id="x4-2-did-core"><span class="secno">4.2 </span>DID Core</h3>
+      <p>The terms in this section are described in the [<cite><a class="bibref" href="#bib-did-core">DID-CORE</a></cite>] specification.</p>
       <ul>
-        <li><a href="https://www.w3.org/TR/did-core/#dfn-alsoknownas" id="alsoKnownAs">alsoKnownAs</a> [<cite><a class="bibref" href="#bib-did-core">DID-CORE</a></cite>]</li>
+        <li>
+          <a href="https://www.w3.org/TR/did-core/#dfn-alsoknownas" id="alsoKnownAs">alsoKnownAs</a> (<code>@id</code>)
+          <ul>
+            <li>Social Web Incubator CG Resolution: <a href="https://www.w3.org/2020/11/07-social-minutes.html#ResolutionSummary">2020-11-07</a></li>
+          </ul>
+        </li>
       </ul>
     </section>
 


### PR DESCRIPTION
... see issue #511.

In the absence of a formal extensibility processes. I would like to discuss this at a SocialCG meeting at some point.

This property is used in multiple implementations (including Mastodon and Zot) who already assume it is available in the `as` namespace. There is some other discussion of this property [on socialhub](https://socialhub.activitypub.rocks/t/defining-alsoknownas/907) by other implementers of the property.