### PR TITLE
Fix/remove broken links from Property Definitions

### DIFF
--- a/ns/index.html
+++ b/ns/index.html
@@ -545,8 +545,6 @@ details.respec-tests-details > li {
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-actor" id="actor">actor</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-attributedto" id="attributedTo">attributedTo</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-attachment" id="attachment">attachment</a> (<code>@id</code>)</li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-attachments" id="attachments">attachments</a> (<code>@id</code>)</li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-author" id="author">author</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-bcc" id="bcc">bcc</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-bto" id="bto">bto</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-cc" id="cc">cc</a> (<code>@id</code>)</li>
@@ -559,7 +557,7 @@ details.respec-tests-details > li {
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-inreplyto" id="inReplyTo">inReplyTo</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-items" id="items">items</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-instrument" id="instrument">instrument</a> (<code>@id</code>)</li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-ordereditems" id="orderedItems">orderedItems</a> (<code>@id</code>)</li>
+        <li><a href="https://www.w3.org/TR/activitystreams-core/#h-collections" id="orderedItems">orderedItems</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-last" id="last">last</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-location" id="location">location</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-next" id="next">next</a> (<code>@id</code>)</li>
@@ -571,13 +569,11 @@ details.respec-tests-details > li {
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-accuracy" id="accuracy">accuracy</a> (<code>xsd:float</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-prev" id="prev">prev</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-preview" id="preview">preview</a> (<code>@id</code>)</li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-provider" id="provider">provider</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-replies" id="replies">replies</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-result" id="result">result</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-audience" id="audience">audience</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-partof" id="partOf">partOf</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-tag" id="tag">tag</a> (<code>@id</code>)</li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-tags" id="tags">tags</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-target" id="target">target</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-to" id="to">to</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-url" id="url">url</a> (<code>@id</code>)</li>
@@ -586,7 +582,6 @@ details.respec-tests-details > li {
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-contentmap" id="contentMap">contentMap</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-name" id="name">name</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-namemap" id="nameMap">nameMap</a> </li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-downstreamduplicates" id="downstreamDuplicates">downstreamDuplicates</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-duration" id="duration">duration</a> (<code>xsd:duration</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-endtime" id="endTime">endTime</a> (<code>xsd:dateTime</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-height" id="height">height</a> (<code>xsd:nonNegativeInteger</code>)</li>
@@ -597,7 +592,6 @@ details.respec-tests-details > li {
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-mediatype" id="mediaType">mediaType</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-published" id="published">published</a> (<code>xsd:dateTime</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-radius" id="radius">radius</a> (<code>xsd:float</code>)</li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-rating" id="rating">rating</a> (<code>xsd:float</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-rel" id="rel">rel</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-startindex" id="startIndex">startIndex</a> (<code>xsd:nonNegativeInteger</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-starttime" id="startTime">startTime</a> (<code>xsd:dateTime</code>)</li>
@@ -606,8 +600,6 @@ details.respec-tests-details > li {
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-totalitems" id="totalItems">totalItems</a> (<code>xsd:nonNegativeInteger</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-units" id="units">units</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-updated" id="updated">updated</a> (<code>xsd:dateTime</code>)</li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-upstreamduplicates" id="upstreamDuplicates">upstreamDuplicates</a> </li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-verb" id="verb">verb</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-width" id="width">width</a> (<code>xsd:nonNegativeInteger</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-describes" id="describes">describes</a> (<code>@id</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-formertype" id="formerType">formerType</a> (<code>@id</code>)</li>


### PR DESCRIPTION
The Property Definitions list in ns/index.html has several property names with broken links. Remove the deprecated ones, and fix the not-deprecated one.

Fixes https://github.com/w3c/activitystreams/issues/525