### PR TITLE
Update ERRATA.md to note lack of aliases for @type and @id

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -4,7 +4,22 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
 
 ## Activity Streams
 
-  - None yet reported.
+  - Example 29 uses `id` as an alias for the `@id` property even though the Activity Streams 2.0 context has not been used, so that alias is not set up. The correct code would be:
+
+    ```json
+    {
+        "@context": {
+            "ex": "http://example.org/",
+            "term": {
+                "@type": "@id",
+                "@id": "ex:term"
+            }
+        },
+        "term": "ex:Foo"
+    }
+    ``` 
+
+   - Section 5.1 incorrectly refers to the `id` alias for the `@id` property, and the `type` alias of the `@type` property. Paragraph 4 should read, in part, ''In JSON-LD, Compact URI expansion of values applies to properties explicitly defined as "@type": "@id" in the @context definition.''
 
 ## Activity Vocabulary
 


### PR DESCRIPTION
The section on Compact URIs mentions how prefixes work. It incorrectly uses the `type` and `id` aliases for `@type` and `@id` when the Activity Streams 2.0 context has not been included. This patch will update the ERRATA to note this error and provide corrected example code and text.