### PR TITLE
Update ERRATA.md

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -4,7 +4,8 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
 
 ## Activity Streams
 
-  - None yet reported.
+  - Section 4.2 lists the possible properties of a `Link` object. This list omits `nameMap`, `preview`, `attributedTo`
+    The full list should be: id | name | nameMap | hreflang | mediaType | rel | height | width | preview | attributedTo.
 
 ## Activity Vocabulary
 


### PR DESCRIPTION
Add an erratum for the core document that gives a full list of the properties of a link, except `href`, to correct section 4.2.