### PR TITLE
s/oneOf/anyOf/ in line 225 of activitystreams2.owl

### DIFF
--- a/vocabulary/activitystreams2.owl
+++ b/vocabulary/activitystreams2.owl
@@ -222,7 +222,7 @@ as:oneOf a owl:ObjectProperty ;
   rdfs:domain as:Question .
 
 as:anyOf a owl:ObjectProperty ;
-  rdfs:label "oneOf"@en ;
+  rdfs:label "anyOf"@en ;
   rdfs:comment "Describes a possible inclusive answer or option for a question."@en ;
   rdfs:range [
     a owl:Class ;


### PR DESCRIPTION
Fixes #556 

The current owl file contains two properties: `as:oneOf` and `as:anyOf` that are both labeled "oneOf". This PR fixes that.