### PR TITLE
Remove specific relationships from JSON-LD context

### DIFF
--- a/ns/activitystreams.jsonld
+++ b/ns/activitystreams.jsonld
@@ -61,10 +61,6 @@
     "Read": "as:Read",
     "Move": "as:Move",
     "Travel": "as:Travel",
-    "IsFollowing": "as:IsFollowing",
-    "IsFollowedBy": "as:IsFollowedBy",
-    "IsContact": "as:IsContact",
-    "IsMember": "as:IsMember",
     "subject": {
       "@id": "as:subject",
       "@type": "@id"


### PR DESCRIPTION
Follows-up on https://github.com/w3c/activitystreams/issues/406

The terms were removed from the specifications (in commit a43c3d44b82dd989181a4150ea4461ca3f8f216a ) but not in JSON-LD context.