### PR TITLE
Update ERRATA.md

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -80,3 +80,24 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
   - Unlike `latitude` and `longitude`, the domain of the `altitude` term is the `Object` type. The `altitude` term should be included in the list of properties of an `Object`. Because `altitude` is primarily documented as a property of a `Place`, publishers should not include `altitude` on objects that are not of type `Place`, and consumers should accept objects with this property that aren't of type `Place`.
 
   - The domain of the `attributedTo` property is both `Link` and `Object`. `attributedTo` should be included in the list of properties of a `Link`.
+
+  - Example 102 is missing a `type` property on the `Link` value of the `url` property. For clarity, the example should read:
+
+  ```json
+  {
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Video",
+  "name": "Cool New Movie",
+  "duration": "PT2H30M",
+  "preview": {
+    "type": "Video",
+    "name": "Trailer",
+    "duration": "PT1M",
+    "url": {
+      "type": "Link",
+      "href": "http://example.org/trailer.mkv",
+      "mediaType": "video/mkv"
+    }
+  }
+}
+```


### PR DESCRIPTION
Based on issue #444 I've added an erratum to show what's potentially the correct value for the type in example 102.

There's some dispute about whether this example is strictly incorrect, and if therefore it's actually an editorial error that belongs in the ERRATA. It's definitely better form, and the lack of a type property is not the point of the example. I'll leave this open to the CG for advice or a decision.