### PR TITLE
Update ERRATA.md

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -80,3 +80,20 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
   - Unlike `latitude` and `longitude`, the domain of the `altitude` term is the `Object` type. The `altitude` term should be included in the list of properties of an `Object`. Because `altitude` is primarily documented as a property of a `Place`, publishers should not include `altitude` on objects that are not of type `Place`, and consumers should accept objects with this property that aren't of type `Place`.
 
   - The domain of the `attributedTo` property is both `Link` and `Object`. `attributedTo` should be included in the list of properties of a `Link`.
+
+  - Example 146 in Activity Vocabulary has an error in the format of the `startTime` property. The full example should be:
+  ```
+  {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "summary": "Sally became a friend of Matt",
+    "type": "Create",
+    "actor": "http://sally.example.org",
+    "object": {
+      "type": "Relationship",
+      "subject": "http://sally.example.org",
+      "relationship": "http://purl.org/vocab/relationship/friendOf",
+      "object": "http://matt.example.org",
+      "startTime": "2015-04-21T12:34:56Z"
+    }
+  }
+  ```


### PR DESCRIPTION
The `startTime` property in Example 146 is missing a terminating Z. This erratum corrects it.