### PR TITLE
Change type for `href` property in context to match document

### DIFF
--- a/ns/activitystreams.jsonld
+++ b/ns/activitystreams.jsonld
@@ -242,7 +242,7 @@
     },
     "href": {
       "@id": "as:href",
-      "@type": "@id"
+      "@type": "xsd:anyURI"
     },
     "hreflang": "as:hreflang",
     "latitude": {


### PR DESCRIPTION
The type for the `href` property in the AS2 context does not match the documentation. This fixes that problem.