### PR TITLE
Add GitHub Action that automatically comments on issues labelled as Needs FEP

### DIFF
--- a/.github/workflows/fep-explainer.yml
+++ b/.github/workflows/fep-explainer.yml
@@ -1,0 +1,23 @@
+name: Add comment to explain Needs FEP label
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  add-comment:
+    if: github.event.label.name == 'needs-fep'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        run: gh issue comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          BODY: >
+            This issue has been labelled as potentially needing a FEP, and contributors are welcome to [submit a FEP](https://codeberg.org/fediverse/fep/src/branch/main#submitting-a-fep) on the topic.
+
+            Note that issues may be closed without the FEP being created; that does not mean that the FEP is no longer needed.


### PR DESCRIPTION
This should help to explain what Needs FEP means, and why issues labelled with it may be closed.

Note: This requires a `GITHUB_TOKEN` secret to be set on the repository.

This is based on this [guide from GitHub](https://docs.github.com/en/actions/use-cases-and-examples/project-management/commenting-on-an-issue-when-a-label-is-added).