### PR TITLE
Correct grammar in definition of `tag`

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -80,3 +80,5 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
   - Unlike `latitude` and `longitude`, the domain of the `altitude` term is the `Object` type. The `altitude` term should be included in the list of properties of an `Object`. Because `altitude` is primarily documented as a property of a `Place`, publishers should not include `altitude` on objects that are not of type `Place`, and consumers should accept objects with this property that aren't of type `Place`.
 
   - The domain of the `attributedTo` property is both `Link` and `Object`. `attributedTo` should be included in the list of properties of a `Link`.
+
+  - The definition of `tag` should read 'One or more "tags" that have been associated with an object. A tag can be any kind of Object. The key difference between `attachment` and `tag` is that the former implies association by inclusion, while the latter implies association by reference.'


### PR DESCRIPTION
This change adds errata to correct the grammar in the definition of the `tag` property. It changes "an objects" to "an object" and "implies associated by" to "implies association by".