### PR TITLE
Erratum for Example 79 to correct `width` and `height` properties

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -80,3 +80,27 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
   - Unlike `latitude` and `longitude`, the domain of the `altitude` term is the `Object` type. The `altitude` term should be included in the list of properties of an `Object`. Because `altitude` is primarily documented as a property of a `Place`, publishers should not include `altitude` on objects that are not of type `Place`, and consumers should accept objects with this property that aren't of type `Place`.
 
   - The domain of the `attributedTo` property is both `Link` and `Object`. `attributedTo` should be included in the list of properties of a `Link`.
+
+  - Example 79 has  an `Image` object with `width` and `height` properties, which
+    are only allowed on `Link` objects. One alternative is to use a `Link` object
+    with the correct `height` and `width` as the `url` property for each `Image`
+    object.
+
+    ```json
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "summary": "A simple note",
+      "type": "Note",
+      "content": "This is all there is.",
+      "icon": {
+        "type": "Image",
+        "name": "Note icon",
+        "url": {
+           "href": "http://example.org/note.png",
+           "type": "Link",
+           "width": 16,
+           "height": 16
+        }
+      }
+    }
+    ```


### PR DESCRIPTION
Example 79 includes an Image with width and height properties that are only allowed for Link objects. This erratum changes the example to move the width and height to the url property.