### PR TITLE
fix: erratum for "core object types" language in section 4 "Model"

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -4,7 +4,7 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
 
 ## Activity Streams
 
-  - None yet reported.
+  - The first sentence in section 4 "Model" should read "The Activity Vocabulary normatively defines the object types and properties for Activity Streams 2.0."
 
 ## Activity Vocabulary
 


### PR DESCRIPTION
Per #634 , the use of the term "core" in the opening sentence of this section is misleading, since it covers both types and properties. The distinction between core types and extended types is made later in the section, so this erratum removes the word "core" from the first sentence.