### PR TITLE
Replaced "MIME media type" with the recommended terminology: "media type"

### DIFF
--- a/core/index.html
+++ b/core/index.html
@@ -262,7 +262,7 @@
         An <dfn>Activity Streams
         Document</dfn> is a JSON document whose root value is an
         Activity Streams <a>Object</a> of any type, including a
-        <a>Collection</a>, and whose MIME media type is
+        <a>Collection</a>, and whose media type ([[!IANA-MEDIA-TYPES]]) is
         "<code>application/activity+json</code>".
       </p>
 
@@ -380,7 +380,7 @@
         <p>
           When a JSON-LD enabled Activity Streams 2.0 implementation encounters
           a JSON document identified using the
-          "<code>application/activity+json</code>" MIME media type, and
+          "<code>application/activity+json</code>" media type, and
           that document does not contain a <code>@context</code> property
           whose value includes a reference to the normative
           <a href="https://www.w3.org/ns/activitystreams">Activity Streams 2.0 JSON-LD
@@ -896,7 +896,7 @@ as2-date-time    = full-date "T" as2-full-time
 </figure>
 
       <figure><figcaption>
-        Alternatively, if additional metadata is required (such as the MIME
+        Alternatively, if additional metadata is required (such as the
         content type of the referenced resource) a <a>Link</a> can be used:
       </figcaption>
 <div id="ex13-jsonld" style="display: block;">
@@ -2000,7 +2000,7 @@ as2-date-time    = full-date "T" as2-full-time
       <h2>The <code>application/activity+json</code> Media Type</h2>
 
       <p>
-        This specification registers the <code><dfn>application/activity+json</dfn></code> MIME Media Type specifically for identifying documents
+        This specification registers the <code><dfn>application/activity+json</dfn></code> media type specifically for identifying documents
         conforming to the Activity Streams 2.0 format.
       </p>
 
@@ -2339,7 +2339,7 @@ profile-URI   = URI</"></"></pre>
 
     <ol>
     <li>
-      Implementations can use the "<code>application/stream+json</code>" MIME
+      Implementations can use the "<code>application/stream+json</code>"
       media type when producing a JSON serialization using the Activity
       Streams 1.0 syntax, and "<code>application/activity+json</code>"
       when producing a serialization conforming to the 2.0 syntax.
@@ -2347,7 +2347,7 @@ profile-URI   = URI</"></"></pre>
     <li>
       Implementations that process serializations identified using either
       the "<code>application/stream+json</code>" or the more
-      generic "<code>application/json</code>" MIME media type MUST follow
+      generic "<code>application/json</code>" media type MUST follow
       the syntax and processing rules set by [[AS1]].  The 2.0
       syntax and processing rules apply only when handling
       serializations using the "<code>application/activity+json</code>" media
@@ -2537,6 +2537,9 @@ profile-URI   = URI</"></"></pre>
       </li>
       <li>
         Updated context examples to include more realistic complex contexts.
+      </li>
+      <li>
+        Replaced "MIME media type" with the recommended terminology: "media type".
       </li>
     </ul>
 

--- a/ns/index.html
+++ b/ns/index.html
@@ -594,7 +594,7 @@ details.respec-tests-details > li {
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-hreflang" id="hreflang">hreflang</a> </li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-latitude" id="latitude">latitude</a> (<code>xsd:float</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-longitude" id="longitude">longitude</a> (<code>xsd:float</code>)</li>
-        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-mediatype" id="mediaType">mediaType</a> </li>
+        <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-mediatype" id="mediaType">mediaType</a> (<code>xsd:string</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-published" id="published">published</a> (<code>xsd:dateTime</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-radius" id="radius">radius</a> (<code>xsd:float</code>)</li>
         <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-rating" id="rating">rating</a> (<code>xsd:float</code>)</li>

--- a/vocabulary/activitystreams2.owl
+++ b/vocabulary/activitystreams2.owl
@@ -497,12 +497,13 @@ as:longitude a owl:DatatypeProperty ,
 as:mediaType a owl:DatatypeProperty ,
        owl:FunctionalProperty ;
   rdfs:label "mediaType"@en ;
-  rdfs:comment "The MIME Media Type"@en ;
+  rdfs:comment "The media type specified by the IANA."@en ;
   rdfs:range xsd:string ;
   rdfs:domain [
     a owl:Class ;
     owl:unionOf (as:Link as:Object)
-  ] .
+  ] ;
+  rdfs:seeAlso <http://www.iana.org/assignments/media-types/> .
 
 as:objectType a owl:DatatypeProperty ,
         owl:FunctionalProperty,

--- a/vocabulary/index.html
+++ b/vocabulary/index.html
@@ -5049,11 +5049,11 @@
           <td>Notes:</td>
           <td>
             <p>
-              When used on a <a>Link</a>, identifies the MIME media type of the
+              When used on a <a>Link</a>, identifies the media type of the
               referenced resource.
             </p>
             <p>
-              When used on an <a>Object</a>, identifies the MIME media
+              When used on an <a>Object</a>, identifies the media
               type of the value of the <code><a>content</a></code> property.
               If not specified, the <code><a>content</a></code> property is
               assumed to contain <code>text/html</code> content.
@@ -5066,7 +5066,7 @@
         </tr>
         <tr>
           <td>Range:</td>
-          <td>MIME Media Type</td>
+          <td><code>xsd:string</code> ([[!IANA-MEDIA-TYPES]])</td>
         </tr>
         <tr>
           <td>Functional:</td>
@@ -6890,6 +6890,9 @@
         Set the domain of the <code><a>first</a></code>,
         <code><a>last</a></code>, and <code><a>current</a></code> properties to
         <code><a>Collection</a></code>.
+      </li>
+      <li>
+        Replaced "MIME media type" with the recommended terminology: "media type".
       </li>
     </ul>
 


### PR DESCRIPTION
This PR is a [class 2 change](https://www.w3.org/policies/process/#class-2) updating the following documents:

* Activity Streams 2.0 (uses "media type", references IANA-MEDIA-TYPES)
* Activity Vocabulary (uses "media type", references IANA-MEDIA-TYPES, clarifies range)
* ActivityStreams 2.0 Terms (clarifies range)
* Activity Streams 2.0 ontology (uses "media type", references IANA-MEDIA-TYPES)
