### PR TITLE
Add AS2 context to Example 60

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -79,4 +79,31 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
 
   - Unlike `latitude` and `longitude`, the domain of the `altitude` term is the `Object` type. The `altitude` term should be included in the list of properties of an `Object`. Because `altitude` is primarily documented as a property of a `Place`, publishers should not include `altitude` on objects that are not of type `Place`, and consumers should accept objects with this property that aren't of type `Place`.
 
+  - Example 60, for the `Tombstone` type, is missing the `@context` property. The correct example should be:
+
+    ```json
+    {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "OrderedCollection",
+      "totalItems": 3,
+      "name": "Vacation photos 2016",
+      "orderedItems": [
+        {
+          "type": "Image",
+          "id": "http://image.example/1"
+        },
+        {
+          "type": "Tombstone",
+          "formerType": "Image",
+          "id": "http://image.example/2",
+          "deleted": "2016-03-17T00:00:00Z"
+        },
+        {
+          "type": "Image",
+          "id": "http://image.example/3"
+        }
+      ]
+    }
+    ```
+
   - The domain of the `attributedTo` property is both `Link` and `Object`. `attributedTo` should be included in the list of properties of a `Link`.


### PR DESCRIPTION
Per issue #441, example 60 is missing its AS2 context. This change adds an erratum to correct this mistake. Once accepted, we can also merge to the editor's version of the spec itself.