### PR TITLE
fix: Erratum for as2-partial-time

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -158,3 +158,9 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
       }
     }
     ```
+
+  - In Section 2.3 "Dates and Times", the definition of `as2-partial-time` allows specifying a `time-secfrac` portion even if `time-second` is not defined. One candidate correction for this error is to replace the ABNF definition of `as2-partial-time` with a structure that requires `time-second` for `time-secfrac` to be used:
+
+  ```
+  as2-partial-time = time-hour ":" time-minute [":" time-second  [time-secfrac]]
+  ```


### PR DESCRIPTION
This is for issue #488 . It provides an erratum that explains the error and provides a candidate correction with a new definition.