### PR TITLE
Update activitystreams2.owl. s/rdfs:name/rdfs:comment/ issue #602

### DIFF
--- a/vocabulary/activitystreams2.owl
+++ b/vocabulary/activitystreams2.owl
@@ -419,7 +419,7 @@ as:content a owl:DatatypeProperty ;
 
 as:name a owl:DatatypeProperty ;
   rdfs:label "name"@en ;
-  rdfs:name "The default, plain-text display name of the object or link."@en ;
+  rdfs:comment "The default, plain-text display name of the object or link."@en ;
   rdfs:range [
     a owl:Class ;
     owl:unionOf ( rdf:langString xsd:string )


### PR DESCRIPTION
Issue #602 describes a problem with the OWL file which uses the wrong property for a comment.

This change fixes the problem.

There was a previous PR that mixed up two different issues; I think this one only addresses the single issue.

@phtyson please confirm!