### PR TITLE
Add erratum for fragment identifiers per issue #610

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -47,6 +47,8 @@ This document includes errata for the [Activity Streams](https://www.w3.org/TR/a
   }
   ```
 
+- Section 8.1, "The application/activity+json Media Type", does not mention considerations for fragment identifiers. In the absence of any defined considerations, one default is to fall back on the same treatment as with JSON-LD. One way to make this explicit is to add this sentence to the end of section 8.1: "Fragment identifiers used with application/activity+json are treated as in RDF syntaxes, as per RDF 1.1 Concepts and Abstract Syntax [RDF11-CONCEPTS]."
+
 ## Activity Vocabulary
 
 - Example 150 has `latitude` and `longitude` properties with string values.


### PR DESCRIPTION
Issue #610 notes that there is no defined considerations for fragment identifiers with AS2. This erratum notes the absence, and suggests an adjustment to default to JSON-LD treatment.