### PR TITLE
Add advisement keywords for non-normative content

### DIFF
--- a/vocabulary/index.html
+++ b/vocabulary/index.html
@@ -167,6 +167,12 @@
       document are to be interpreted as described in [[!RFC2119]].
     </p>
 
+    <p id="advisement-levels">
+      The key words "strongly encouraged", "strongly discouraged",
+      "encouraged", "discouraged", "can", "cannot", "could", "could not", "might",
+      and "might not" are used for non-normative content.
+    </p>
+
     <section id="termconventions">
 
       <h2>Conventions</h2>


### PR DESCRIPTION
This is a [correction class 2 change](https://www.w3.org/policies/process/#class-2) introducing advisement level keywords for non-normative content. It is a step towards distinguishing terminology used for normative and non-normative content.

Terms for advisement levels are borrowed from [INFRA's Conformance](https://infra.spec.whatwg.org/#conformance).

---

Currently, conformance content, such as the paragraph on requirement levels, is included in the Introduction section. If/when this PR is merged, I plan to follow up with a separate PR to create a dedicated Conformance section, including requirement levels, advisement levels, and other details.

Motivation for this PR was https://github.com/w3c/activitystreams/pull/627 as it seeks to clarify normative language from non-normative content.

And so this should help make the spec clearer and more consistent for both authors and readers.