### PR TITLE
"Core types include" -> "Core types are"

### DIFF
--- a/core/index.html
+++ b/core/index.html
@@ -613,7 +613,7 @@ as2-date-time    = full-date "T" as2-full-time
     <p>
       The object types defined by the vocabulary are segmented into a set of
       eight core types and an extended set of Activity and Object types common
-      to many social Web applications. The core types include:
+      to many social Web applications. The core types are:
       <ul>
         <li><a>Object</a>,</li>
         <li><a>Link</a>,</li>


### PR DESCRIPTION
Fix #704

Note that this concept of "core types" can be revisited in other issues. This commit only fixes the wording.